### PR TITLE
feature(server/express) add domain seperation

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,54 +1,60 @@
  (function() {
     'use strict';
-    
+
     var DIR_LIB             = './',
         DIR_SERVER          = DIR_LIB   + 'server/',
-        
+
         http                = require('http'),
-        
+
         cloudcmd            = require(DIR_LIB + 'cloudcmd'),
         exit                = require(DIR_SERVER + 'exit'),
         config              = require(DIR_SERVER + 'config'),
         express             = require(DIR_SERVER + 'express'),
-        io                  = require('socket.io');
-    
+        io                  = require('socket.io'),
+        expressdomain      = require('express-domain-middleware');
+
     /**
      * start server function
      *
      */
     module.exports  = function(options) {
         var server,
-            
+
             port    =   process.env.PORT            ||  /* c9           */
                         process.env.VCAP_APP_PORT   ||  /* cloudfoundry */
                         config('port'),
-            
+
             ip      =   process.env.IP              ||  /* c9           */
                         config('ip')                ||
                         '0.0.0.0',
-            
+
             app      = express.getApp({
                 auth    : config('auth'),
                 username: config('username'),
                 password: config('password')
             });
-        
+
         server          = http.createServer(app);
-        
+
+        app.use(expressdomain);
+        app.use(function errorHandler(err, req, res, next) {
+          console.log("this stopped node from crashing.");
+        });
+
         app.use(cloudcmd({
             config: options,
             socket: io.listen(server)
         }));
-        
+
         if (port <= 0 || port > 65535)
             exit('cloudcmd --port: %s', 'port number could be 1..65535');
-        
+
         server.on('error', function(error) {
             exit('cloudcmd --port: %s', error.message);
         });
-        
+
         server.listen(port, ip);
-        
+
         console.log('url: http://%s:%d', config('ip') || 'localhost', port);
     };
 })();

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,7 +38,7 @@
 
         app.use(expressdomain);
         app.use(function errorHandler(err, req, res, next) {
-          console.log("this stopped node from crashing.");
+          console.log('error on request %d %s %s', process.domain.id, req.method, req.url);
         });
 
         app.use(cloudcmd({

--- a/lib/server/express.js
+++ b/lib/server/express.js
@@ -1,29 +1,30 @@
 (function() {
     'use strict';
-    
+
     var DIR                 = __dirname + '/../../',
         DIR_LIB             = DIR + 'lib/',
-        
+
         Util                = require(DIR_LIB + 'util'),
-        
+
         tryRequire          = require('tryrequire'),
-        
+
         express             = require('express'),
         logger              = tryRequire('morgan'),
-        
+
         app                 = express();
-    
+
     exports.getApp          = function(middleware) {
+        console.log(middleware);
         var isArray = Util.type.array(middleware);
-        
+
         if (logger)
             app.use(logger('dev'));
-        
+
         if (isArray)
             middleware.forEach(function(middle) {
                 app.use(middle);
             });
-        
+
         return app;
     };
 })();

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "edward": "~2.0.0",
     "execon": "~1.2.0",
     "express": "~4.13.0",
+    "express-domain-middleware": "^0.1.0",
     "faust": "~1.0.0",
     "files-io": "~1.2.0",
     "flop": "~1.3.0",


### PR DESCRIPTION
while running cloudcmd with reduced privileges such as nologin for the shell, terminal tool had caused a crash after 3 attempts to list files inside a directory it had no access to read