### PR TITLE
fix(client) Add prefix to menu.

### DIFF
--- a/lib/client/menu.js
+++ b/lib/client/menu.js
@@ -283,7 +283,8 @@ var CloudCmd, Util, DOM, CloudFunc, MenuIO;
         
         function download() {
             var TIME        = 30 * 1000,
-                apiURL      = CloudFunc.apiURL,
+                prefix      = CloudCmd.PREFIX,
+                apiURL      = prefix + CloudFunc.apiURL,
                 FS          = CloudFunc.FS,
                 date        = Date.now(),
                 files       = DOM.getActiveFiles();


### PR DESCRIPTION
I'm experimenting with this as middleware and noticed that the download option didn't have the CloudCmd.PREFIX.

Adding the prefix to the link fixed the download option.

I patterned the fix after your code at:  https://github.com/coderaiser/cloudcmd/blob/master/lib/client/load.js#L222-L223