### PR TITLE
fix(index) prefix favicon link

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -6,7 +6,7 @@
         <meta name="theme-color" content="rgb(49,123,249)">
         <!-- mobile first design -->
         <meta content="width=device-width,initial-scale=1" name="viewport">
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="{{ prefix }}/favicon.ico" />
         <title>{{ title }}</title>
         
         <link rel=stylesheet href="{{ prefix }}/css/urls.css">


### PR DESCRIPTION
Favicon uses a relative link. This fixes the 403 error when using with a prefix.