### PR TITLE
fix(view) image and media path fancybox fixes

### DIFF
--- a/lib/client/view.js
+++ b/lib/client/view.js
@@ -191,7 +191,7 @@ var CloudCmd, Util, DOM, CloudFunc, $;
                         return name !== current;
                     }).map(function(name) {
                         return {
-                            href: name,
+                            href:  CloudCmd.PREFIX + CloudFunc.apiURL + CloudFunc.FS + name,
                             title: name
                         };
                     });

--- a/lib/client/view.js
+++ b/lib/client/view.js
@@ -122,7 +122,7 @@ var CloudCmd, Util, DOM, CloudFunc, $;
                     
                 } else {
                     Images.show.load();
-                    path    = CloudFunc.FS + Info.path;
+                    path    = CloudCmd.PREFIX + CloudFunc.apiURL + CloudFunc.FS + Info.path;
                     type    = getType(path);
                     
                     switch(type) {

--- a/lib/client/view.js
+++ b/lib/client/view.js
@@ -181,11 +181,12 @@ var CloudCmd, Util, DOM, CloudFunc, $;
             $.fancybox.close();
         }
         
-        function showImage() {
+        function showImage(path) {
             var config,
-                current = Info.name,
-                files   = [].slice.call(Info.files),
-                names   = DOM.getFilenames(files)
+                currentPath = path,
+                current     = Info.name,
+                files       = [].slice.call(Info.files),
+                names       = DOM.getFilenames(files)
                     .filter(isImage)
                     .filter(function(name) {
                         return name !== current;
@@ -197,7 +198,7 @@ var CloudCmd, Util, DOM, CloudFunc, $;
                     });
             
             names.unshift({
-                href: current,
+                href: currentPath,
                 title: current
             });
             


### PR DESCRIPTION
Images were not displaying if in root location.

Media paths for video files were also failing to open with the prefix.

Images in root before:

![before_view](https://cloud.githubusercontent.com/assets/2374718/13361201/3fdd640c-dc8b-11e5-842c-af5286f195c6.png)

Images in root after:

![after_view](https://cloud.githubusercontent.com/assets/2374718/13361208/4b466096-dc8b-11e5-8dd1-d7cd03182e74.png)

Using the apiURL made the images and media resize the fancybox appropriately as well.

I added (path) param to showImage() signature, since it was getting called with path but it wasn't being used for the href.