### PR TITLE
fix(client: load) specify 'X-Requested-With' on XMLHttpRequests

### DIFF
--- a/lib/client/load.js
+++ b/lib/client/load.js
@@ -175,6 +175,15 @@
                 xhr         = new XMLHttpRequest();
             
             xhr.open(type, p.url, true);
+
+	    // X-Requested-With header
+	    // For cross-domain requests, seeing as conditions for a preflight are
+	    // akin to a jigsaw puzzle, we simply never set it to be sure.
+	    // (it can always be set on a per-request basis or even using ajaxSetup)
+	    // For same-domain requests, won't change header if already provided.
+	    if ( !Object.keys(headers)[ "X-Requested-With" ] ) {
+		xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+	    }
             
             Object.keys(headers).forEach(function(name) {
                 var value = headers[name];
@@ -229,6 +238,8 @@
             url     = url.replace('#', '%23');
             
             xhr.open('put', api + url, true);
+
+            xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
             
             xhr.upload.onprogress = function(event) {
                 var percent, count;


### PR DESCRIPTION
Added "X-Requested-With" header to XMLHttpRequest calls.

Apache is timing out after five minutes and wiping the session, causing us to have to reauthenticate with our openid provider. Adding this header tells the server that it's an Ajax call so it doesn't try to start a new session.

jQuery adds this header by default, and I basically just patterned this fix after their code.

https://github.com/jquery/jquery/blob/769446c69775f6c44e35cee1bcdeccafba51be7b/src/ajax/xhr.js#L57-L69

See here for a discussion:

http://stackoverflow.com/questions/12533435/xmlhttprequest-not-adding-header-x-requested-with-xmlhttprequest