### PR TITLE
fix(config) file permission security

### DIFF
--- a/lib/server/config.js
+++ b/lib/server/config.js
@@ -73,7 +73,7 @@
     }
     
     function save(callback) {
-        writejson(ConfigHome, config, callback);
+        writejson(ConfigHome, config, { mode: '0o600' }, callback);
     }
     
     function listen(sock, authCheck) {


### PR DESCRIPTION
This fix changes the permission of the created file to prevent write access by other system users.

This is a standard config option of [fs.writeFile()](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback) which this gets passed to via writejson.

Note: `mode` specifies the permissions to use in case a new file is created. So if the file is already present it will not be modified.