### PR TITLE
feature(docker) Re-target nodejs layer to the one provided for RPi

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,0 +1,15 @@
+#FROM node
+FROM hypriot/rpi-node:slim
+MAINTAINER Valentin Alexeev <valentin.alekseev@gmail.com>
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install --production
+COPY . /usr/src/app
+
+EXPOSE 8000
+
+ENTRYPOINT ["bin/cloudcmd.js"]
+


### PR DESCRIPTION
I have added a small Dockerfile to support CloudCmd on Raspberry Pi.

The corresponding image is now on Docker Hub as valentinalexeev/rpi-cloudcmd