### PR TITLE
fix(auth) check for password length of 0

### DIFF
--- a/lib/server/auth.js
+++ b/lib/server/auth.js
@@ -36,7 +36,8 @@
             algo    = config('algo');
         
         sameName    = username === name;
-        samePass    = pass === criton(password, algo);
+        samePass    =    (password.length > 0) 
+                      && (pass === criton(password, algo));
         
         callback(sameName && samePass);
     }

--- a/lib/server/auth.js
+++ b/lib/server/auth.js
@@ -36,8 +36,7 @@
             algo    = config('algo');
         
         sameName    = username === name;
-        samePass    =    (password.length > 0) 
-                      && (pass === criton(password, algo));
+        samePass    = (password.length > 0) && (pass === criton(password, algo));
         
         callback(sameName && samePass);
     }


### PR DESCRIPTION
<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

[x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
[x] `npm run codestyle` is OK
[x] `npm test` is OK

Check for a non-zero length password before making the call to criton for hash verification.

If the user attempts to login in when authorization is enabled and fails to supply a password, the headers don't get properly cleared (in Chrome) leading to an unescapable loop even when stopping and restarting the service.