### PR TITLE
fix(operation) English spelling

### DIFF
--- a/lib/client/operation.js
+++ b/lib/client/operation.js
@@ -281,7 +281,7 @@
                 if (n >= 5)
                     name   += '\n...';
                 
-                msg    = msgAsk + msgSel + n + ' files/directoris?\n' + name ;
+                msg    = msgAsk + msgSel + n + ' files/directories?\n' + name ;
             } else {
                 isDir       = DOM.isCurrentIsDir(current);
                 


### PR DESCRIPTION
<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

Noticed the English spelling was off on a multiple file delete operation.

[X] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
[X] `npm run codestyle` is OK
[X] `npm test` is OK


