### PR TITLE
feature(contact): add config to hide contact button

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -86,6 +86,7 @@ Cloud Commander supports command line parameters:
 | `--console`                   | enable console
 | `--terminal`                  | enable terminal
 | `--terminal-path`             | set terminal path
+| `--contact`                   | enable contact
 | `--no-server`                 | do not start server
 | `--no-auth`                   | disable authorization
 | `--no-online`                 | load scripts from local server
@@ -96,6 +97,7 @@ Cloud Commander supports command line parameters:
 | `--no-config-dialog`          | disable config dialog
 | `--no-console`                | disable console
 | `--no-terminal`               | disable terminal
+| `--no-contact`                | disable contact
 | `--no-name`                   | set empty tab name in web browser
 
 

--- a/bin/cloudcmd.js
+++ b/bin/cloudcmd.js
@@ -12,7 +12,7 @@ const env = require(DIR_SERVER + 'env');
 const choose = (a, b) => {
     if (!a && typeof a !== 'boolean')
         return b;
-    
+
     return a;
 };
 
@@ -41,6 +41,7 @@ const args = require('minimist')(argv.slice(2), {
         'config-dialog',
         'console',
         'terminal',
+        'contact',
         'one-panel-mode',
         'html-dialogs',
         'show-config',
@@ -61,7 +62,8 @@ const args = require('minimist')(argv.slice(2), {
         progress    : config('progress'),
         console     : config('console'),
         terminal    : choose(env.bool('terminal'), config('terminal')),
-        
+        contact     : config('contact'),
+
         'terminal-path': env('terminal_path') || config('terminalPath'),
         'config-dialog': choose(env.bool('config_dialog'), config('configDialog')),
         'one-panel-mode': config('onePanelMode'),
@@ -92,11 +94,11 @@ else
 function main() {
     if (args.repl)
         repl();
-    
+
     checkUpdate();
-    
+
     port(args.port);
-    
+
     config('name', args.name);
     config('auth', args.auth);
     config('online', args.online);
@@ -104,6 +106,7 @@ function main() {
     config('username', args.username);
     config('progress', args.progress);
     config('console', args.console);
+    config('contact', args.contact);
     config('terminal', args.terminal);
     config('terminalPath', args['terminal-path']);
     config('editor', args.editor);
@@ -112,29 +115,29 @@ function main() {
     config('htmlDialogs', args['html-dialogs']);
     config('onePanelMode', args['one-panel-mode']);
     config('configDialog', args['config-dialog']);
-    
+
     readConfig(args.config);
-    
+
     const options = {
         root: args.root || '/', /* --no-root */
         editor: args.editor,
         packer: args.packer,
         prefix: args.prefix
     };
-    
+
     const password = env('password') || args.password;
-    
+
     if (password)
         config('password', getPassword(password));
-    
+
     validateRoot(options.root);
-    
+
     if (args['show-config'])
         showConfig();
-    
+
     if (!args.save)
         return start(options);
-    
+
     config.save(() => {
         start(options);
     });
@@ -147,7 +150,7 @@ function validateRoot(root) {
 
 function getPassword(password) {
     const criton = require('criton');
-    
+
     return criton(password, config('algo'));
 }
 
@@ -157,48 +160,48 @@ function version() {
 
 function start(config) {
     const SERVER = DIR_SERVER + 'server';
-    
+
     if (args.server)
         require(SERVER)(config);
 }
 
 function port(arg) {
     const number = parseInt(arg, 10);
-    
+
     if (!isNaN(number))
         return config('port', number);
-    
+
     exit('cloudcmd --port: should be a number');
 }
 
 function showConfig() {
     const show = require('../server/show-config');
     const data = show(config('*'));
-    
+
     console.log(data);
 }
 
 function readConfig(name) {
     if (!name)
         return;
-    
+
     const fs = require('fs');
     const tryCatch = require('try-catch');
     const jju = require('jju');
-    
+
     const readjsonSync = (name) => jju.parse(fs.readFileSync(name, 'utf8'), {
         mode: 'json'
     });
-    
+
     let data;
-    
+
     const error = tryCatch(() => {
         data = readjsonSync(name);
     });
-    
+
     if (error)
         return exit(error.message);
-    
+
     Object.keys(data).forEach((item) => {
         config(item, data[item]);
     });
@@ -208,14 +211,14 @@ function help() {
     const bin = require('../json/help');
     const usage = 'Usage: cloudcmd [options]';
     const url = Info.homepage;
-    
+
     console.log(usage);
     console.log('Options:');
-    
+
     Object.keys(bin).forEach((name) => {
         console.log('  %s %s', name, bin[name]);
     });
-    
+
     console.log('\nGeneral help using Cloud Commander: <%s>', url);
 }
 
@@ -227,7 +230,7 @@ function repl() {
 function checkUpdate() {
     const load = require('package-json');
     const noop = () => {};
-    
+
     load(Info.name, 'latest')
         .then(showUpdateInfo)
         .catch(noop);
@@ -235,19 +238,19 @@ function checkUpdate() {
 
 function showUpdateInfo(data) {
     const version = data.version;
-    
+
     if (version !== Info.version) {
         const chalk = require('chalk');
         const rendy = require('rendy');
-        
+
         const latest = rendy('update available: {{ latest }}', {
             latest: chalk.green.bold('v' + version),
         });
-        
+
         const current = chalk.dim(rendy('(current: v{{ current }})', {
             current: Info.version
         }));
-        
+
         console.log('%s %s', latest, current);
     }
 }

--- a/json/config.json
+++ b/json/config.json
@@ -23,7 +23,7 @@
     "htmlDialogs": true,
     "configDialog": true,
     "onePanelMode": false,
-    "configDialog": true,
+    "contact": true,
     "console": true,
     "terminal": false,
     "terminalPath": "",

--- a/json/help.json
+++ b/json/help.json
@@ -20,6 +20,7 @@
     "--console                  ": "enable console",
     "--terminal                 ": "enable terminal",
     "--terminal-path            ": "set terminal path",
+    "--contact                  ": "enable contact",
     "--open                     ": "open web browser when server started",
     "--name                     ": "set tab name in web browser",
     "--no-server                ": "do not start server",
@@ -32,5 +33,6 @@
     "--no-config-dialog         ": "disable config dialog",
     "--no-console               ": "disable console",
     "--no-terminal              ": "disable terminal",
+    "--no-contact               ": "disable contact",
     "--no-name                  ": "set default tab name in web browser"
 }

--- a/man/cloudcmd.1
+++ b/man/cloudcmd.1
@@ -43,6 +43,7 @@ programs in browser from any computer, mobile or tablet device.
   --console                     enable console
   --terminal                    enable terminal
   --terminal-path               set terminal path
+  --contact                     enable contact
   --open                        open web browser when server started
   --name                        set tab name in web browser
   --no-auth                     disable authorization
@@ -55,6 +56,7 @@ programs in browser from any computer, mobile or tablet device.
   --no-config-dialog            disable config dialog
   --no-console                  disable console
   --no-terminal                 disable terminal
+  --no-contact                  disable contact
   --no-name                     set default tab name in web browser
 
 .SH RESOURCES AND DOCUMENTATION

--- a/test/server/route.js
+++ b/test/server/route.js
@@ -29,14 +29,14 @@ test('cloudcmd: route: no args', (t) => {
 
 test('cloudcmd: route: no res', (t) => {
     const fn = () => route({});
-    
+
     t.throws(fn, /res could not be empty!/, 'should throw when no res');
     t.end();
 });
 
 test('cloudcmd: route: no next', (t) => {
     const fn = () => route({}, {});
-    
+
     t.throws(fn, /next should be function!/, 'should throw when no next');
     t.end();
 });
@@ -45,7 +45,7 @@ test('cloudcmd: route: buttons: no console', (t) => {
     const config = {
         console: false
     };
-    
+
     before({config}, (port, after) => {
         getStr(`http://localhost:${port}/`)
             .then((result) => {
@@ -60,7 +60,7 @@ test('cloudcmd: route: buttons: no terminal', (t) => {
     const config = {
         terminal: false
     };
-    
+
     before({config}, (port, after) => {
         getStr(`http://localhost:${port}/`)
             .then((result) => {
@@ -71,11 +71,26 @@ test('cloudcmd: route: buttons: no terminal', (t) => {
     });
 });
 
+test('cloudcmd: route: buttons: no contact', (t) => {
+    const config = {
+        contact: false
+    };
+
+    before({config}, (port, after) => {
+        getStr(`http://localhost:${port}/`)
+            .then((result) => {
+                t.ok(/icon-contact none/.test(result), 'should hide contact');
+                t.end();
+                after();
+            });
+    });
+});
+
 test('cloudcmd: route: buttons: no config', (t) => {
     const config = {
         configDialog: false
     };
-    
+
     before({config}, (port, after) => {
         getStr(`http://localhost:${port}/`)
             .then((result) => {


### PR DESCRIPTION
Fixes #125

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run codestyle` is OK
- [x] `npm test` is OK

I tested this manually by running `npm run build:start:dev` - the other start scripts wouldn't work. They started something and logged a get request, but the browser was never able to load the page.

Somewhat similarily, `npm test` gets stuck on "# cloudcmd: console: enabled by default", even before I changed anything, so that's not OK, but I have no idea why.

I couldn't figure out how to test the command line arguments (`--console` and `--no-console`).

As for the actual changes:
* There are some trailing whitespace removals that my editor did, I can revert those if necessary.
* I removed the duplicate `configDialog` property in config.json
* The rest should be pretty straight-forward