### PR TITLE
fix(download) encode `#` in filename after `encodeURI(path)`

### DIFF
--- a/client/modules/menu.js
+++ b/client/modules/menu.js
@@ -314,11 +314,10 @@ function MenuProto(Position) {
               * no need in hash so we escape #
               * and all other characters, like "%"
               */
-            const path = DOM.getCurrentPath(file)
-                .replace(/#/g, '%23');
+            const path = DOM.getCurrentPath(file);
             
             CloudCmd.log('downloading file ' + path + '...');
-            const encodedPath = encodeURI(path);
+            const encodedPath = encodeURI(path).replace(/#/g, '%23');
             const id = load.getIdBySrc(path);
             
             let src;


### PR DESCRIPTION
- [X] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [ ] `npm run codestyle` is OK
- [ ] `npm test` is OK

Tested in docker container on home server

#80 