### PR TITLE
feature(cloudcmd_prefix) add env variable for path prefix

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -443,6 +443,7 @@ Some config options can be overridden with environment variables, such as:
 - `CLOUDCMD_AUTH` - enable authentication
 - `CLOUDCMD_USERNAME` - set username
 - `CLOUDCMD_PASSWORD` - set password
+- `CLOUDCMD_PREFIX` - set the path prefix for the url
 - `CLOUDCMD_ROOT` - set root directory
 - `CLOUDCMD_VIM` - enable vim hot keys
 - `CLOUDCMD_CONFIRM_COPY` - confirm copy

--- a/bin/cloudcmd.js
+++ b/bin/cloudcmd.js
@@ -92,7 +92,7 @@ const args = require('minimist')(argv.slice(2), {
         'zip'         : config('zip'),
         'username'    : env('username') || config('username'),
         'root'        : choose(env('root'), config('root')),
-        'prefix'      : config('prefix'),
+        'prefix'      : choose(env('cloudcmd_prefix'), config('prefix'),
         'console'     : choose(env.bool('console'), config('console')),
         'contact'     : choose(env.bool('contact'), config('contact')),
         'terminal'    : choose(env.bool('terminal'), config('terminal')),

--- a/bin/cloudcmd.js
+++ b/bin/cloudcmd.js
@@ -92,7 +92,7 @@ const args = require('minimist')(argv.slice(2), {
         'zip'         : config('zip'),
         'username'    : env('username') || config('username'),
         'root'        : choose(env('root'), config('root')),
-        'prefix'      : choose(env('cloudcmd_prefix'), config('prefix'),
+        'prefix'      : choose(env('cloudcmd_prefix'), config('prefix')),
         'console'     : choose(env.bool('console'), config('console')),
         'contact'     : choose(env.bool('contact'), config('contact')),
         'terminal'    : choose(env.bool('terminal'), config('terminal')),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,14 @@ services:
       - ~:/root
       - /:/mnt/fs
     image: coderaiser/cloudcmd
-
+    environment:
+      - CLOUDCMD_PREFIX='/cloudcommand'
+    container_name: cloudcommander
+    networks:
+      - proxy
+networks:
+  traefik_proxy:
+    external:
+      name: proxy
+  default:
+    driver: bridge


### PR DESCRIPTION
- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run codestyle` is OK
- [x] `npm test` is OK

I'm unsure if I got all the additions required, if something is missing I can update the PR.