### PR TITLE
Fix mismatched labels between pod and service

### DIFF
--- a/k8s.yml
+++ b/k8s.yml
@@ -23,11 +23,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: cloudcmd
+      app: cloudcmd-pv
   template:
     metadata:
       labels:
-        app: cloudcmd
+        app: cloudcmd-pv
     spec:
       containers:
         - name: cloudcmd


### PR DESCRIPTION
<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [X] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [X] `npm run codestyle` is OK
- [X] `npm test` is OK

