### PR TITLE
feature(style) - added inverted selection style for current file under cursor

### DIFF
--- a/css/query.css
+++ b/css/query.css
@@ -99,12 +99,8 @@
     
     /* текущий файл под курсором */
     .current-file {
-        background-color: var(--color-transparent);
-        color: white;
-    }
-    /* делаем иконки под курсом белыми */
-    .current-file a {
-        color: white;
+        background-color: rgba(255, 255, 255, 1);
+        filter: invert(1); /* Inverted color for current file selection. */
     }
     
     .file::before, .file-link::before {

--- a/css/style.css
+++ b/css/style.css
@@ -165,6 +165,8 @@ a:hover, a:active {
 
 .current-file {
     box-shadow: 0 0 0 1px var(--color-transparent) inset;
+    background-color: rgba(255, 255, 255, 1);
+    filter: invert(1); /* Inverted color for current file selection. */
 }
 
 .cut-file {


### PR DESCRIPTION
Added inverted selection style for current file under cursor #275 

![image](https://user-images.githubusercontent.com/14835387/94992395-59405e00-05a7-11eb-83ec-6b159256b34c.png)

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run codestyle` is OK
- [x] `npm test` is OK

