### PR TITLE
feature(DOM) Change getCurrentName to use `data-name` 

### DIFF
--- a/client/dom/current-file.js
+++ b/client/dom/current-file.js
@@ -41,7 +41,7 @@ module.exports.setCurrentName = (name, current) => {
     link.href = dir + encoded;
     link.innerHTML = encoded;
     
-    current.setAttribute('data-name', 'js-file-' + btoa(encodeURI(name)));
+    current.setAttribute('data-name', this.createNameAttribute(name));
     CloudCmd.emit('current-file', current);
     
     return link;
@@ -58,13 +58,30 @@ module.exports.getCurrentName = (currentFile) => {
     if (!current)
         return '';
     
-    const link = DOM.getCurrentLink(current);
+    const name_attr = current.getAttribute("data-name");
     
-    if (!link)
+    if (!name_attr)
         return '';
     
-    return decode(link.title)
-        .replace(NBSP_REG, SPACE);
+    return this.parseNameAttribute(name_attr);
+};
+
+/** 
+ * Generate a `data-name` attribute for the given filename
+ * @param name The string name to encode
+ */
+module.exports.createNameAttribute = (name) => {
+    let encoded = btoa(encodeURI(name));
+    return `js-file-${encoded}`;
+};
+
+/**
+ * Parse a `data-name` attribute string back into the original filename
+ * @param attribute The string we wish to decode
+ */
+module.exports.parseNameAttribute = (attribute) => {
+    attribute = attribute.replace("js-file-", "");
+    return decodeURI(atob(attribute));
 };
 
 /**

--- a/client/dom/current-file.spec.js
+++ b/client/dom/current-file.spec.js
@@ -54,6 +54,32 @@ test('current-file: setCurrentName: setAttribute: cyrillic', (t) => {
     t.end();
 });
 
+
+test('current-file: getCurrentName', (t) => {
+    const {
+        DOM,
+        CloudCmd,
+    } = global;
+    
+    global.DOM = getDOM();
+    global.CloudCmd = getCloudCmd();
+    
+    const current = create();
+
+    let filename = "hello world.txt"
+    
+    // Should have basic symmetry, and be resilient to changes in title
+    currentFile.setCurrentName(filename, current);
+    current.setAttribute("title", "not_at_all_correct");
+    t.equal(currentFile.getCurrentName(current), filename);
+
+    global.DOM = DOM;
+    global.CloudCmd = CloudCmd;
+    
+    t.end();
+});
+
+
 test('current-file: emit', (t) => {
     const {
         DOM,


### PR DESCRIPTION
Resolves #313 

Previous behaviour was to read from `title`, which caused problems with extensions that edit the title attribute (such as Imagus for firefox). New behavior should be more resilient

Separated out `data-name` generation/parsing logic into their own functions.
Added test case. _Currently failing due to strange `getAttribute` behavior in test environment._

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [ ] `npm run codestyle` is OK   _I am getting `missing script: codestyle`_
- [ ] `npm test` is OK

