### PR TITLE
fix(docker) images: make dockerfiles use node:lts-buster-slim as base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:lts-buster-slim
 LABEL maintainer="Coderaiser"
 
 RUN mkdir -p /usr/src/app

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:lts-buster-slim
+FROM node:alpine
 LABEL maintainer="Coderaiser"
 
 RUN mkdir -p /usr/src/app

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:lts-buster-slim
 LABEL maintainer="Coderaiser"
 
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
@coderaiser : It seems that the regular Node docker images cannot be executed on arm architecture anymore. This leads to weird errors while starting the containers. 

After some further analysis I found that the issue can be resolved by using a different base docker image (buster-slim) of Node.

For more info [read here](https://issueexplorer.com/issue/louislam/uptime-kuma/372)

I therefore updated the two Dockerfiles to match fix this issue.

This fix will also resolve https://github.com/coderaiser/cloudcmd/issues/357

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run codestyle` is OK
- [x] `npm test` is OK
