### PR TITLE
fix(docker) images: make dockerfiles use node:lts-buster and node:lts-buster-slim for alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-buster-slim
+FROM node:lts-buster
 LABEL maintainer="Coderaiser"
 
 RUN mkdir -p /usr/src/app

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:lts-buster-slim
 LABEL maintainer="Coderaiser"
 
 RUN mkdir -p /usr/src/app
@@ -8,12 +8,12 @@ COPY package.json /usr/src/app/
 
 RUN npm config set package-lock false && \
     npm install --production && \
-    apk update && \
-    apk add --no-cache bash make g++ python3 && \
+    apt update && \
+    apt install -y make g++ python3 && \
     npm i gritty && \
     npm cache clean --force && \
-    apk del make g++ python3 && \
-    rm -rf /usr/include /tmp/* /var/cache/apk/*
+    apt remove -y make g++ python3 && \
+    rm -rf /usr/include /tmp/* /var/cache/apt/*
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
I updated the base images again, because the `*-slim` images do not consist of `python`, `make` and `g++` whereas the regular `buster` images does. So this changes do the following:

- `Dockerfile` :  based on `node:lts-buster`
- `Dockerfile.alpine` : based on `node:lts-buster-slim` (in here we of course need to temporarily install `python`, `make` and `g++`

This is PR is still related to #357 

Whenever we found a fix for the "real" `node:alpine` image, I will create a new PR :)

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run codestyle` is OK
- [x] `npm test` is OK
