### PR TITLE
chore(docker) ci: update GitHub action to use redrun

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Install Redrun
         run: npm i redrun -g
       - name: NPM Install
-        run: Lint
+        run: npm install
       - name: Lint
-        run: redrun fix:lint
+        run: redrun lint
       - name: Build
         id: build
         run: >

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,21 +9,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+      - name: Install Redrun
+        run: npm i redrun -g
       - name: NPM Install
-        run: |
-          npm install
-      - name: NPM Lint
-        run: |
-          npm run lint
-      - name: NPM Build
-        id: npm-build
+        run: Lint
+      - name: Lint
+        run: redrun fix:lint
+      - name: Build
+        id: build
         run: >
-          npm run build
-
+          redrun build
+          
           echo "::set-output name=version::$(grep '"version":' package.json -m1 | cut -d\" -f4)"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -43,7 +43,7 @@ jobs:
           push: true
           tags: |
             coderaiser/cloudcmd:latest
-            coderaiser/cloudcmd:${{ steps.npm-build.outputs.version }}
+            coderaiser/cloudcmd:${{ steps.build.outputs.version }}
       - name: Build and push alpine-image
         uses: docker/build-push-action@v2
         with:
@@ -53,4 +53,4 @@ jobs:
           push: true
           tags: |
             coderaiser/cloudcmd:latest-alpine
-            coderaiser/cloudcmd:${{ steps.npm-build.outputs.version }}-alpine
+            coderaiser/cloudcmd:${{ steps.build.outputs.version }}-alpine


### PR DESCRIPTION
Updating GitHub action for Docker build to use `redrun` instead of regular `npm run` commands

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run codestyle` is OK
- [x] `npm test` is OK
