### PR TITLE
chore(service-worker) migrate to service-worker-webpack

### DIFF
--- a/.webpack/js.js
+++ b/.webpack/js.js
@@ -9,7 +9,7 @@ const {
 const {EnvironmentPlugin} = require('webpack');
 const WebpackBar = require('webpackbar');
 
-const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin');
+const { ServiceWorkerPlugin } = require('service-worker-webpack');
 
 const dir = './client';
 const dirModules = './client/modules';
@@ -51,10 +51,7 @@ const plugins = [
         NODE_ENV,
     }),
     
-    new ServiceWorkerWebpackPlugin({
-        entry: join(__dirname, '..', 'client', 'sw', 'sw.js'),
-        excludes: ['*'],
-    }),
+    new ServiceWorkerPlugin(),
     
     new WebpackBar(),
 ];

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "rimraf": "^4.0.5",
     "scroll-into-view-if-needed": "^3.0.4",
     "serve-once": "^2.0.0",
-    "serviceworker-webpack-plugin": "^1.0.1",
+    "service-worker-webpack": "^1.0.0",
     "smalltalk": "^4.0.0",
     "style-loader": "^2.0.0",
     "supermenu": "^4.0.1",


### PR DESCRIPTION
Following up on https://github.com/tatethurston/service-worker-webpack/issues/1

- [X] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [ ] `npm run codestyle` is OK
- [ ] `npm test` is OK
