### PR TITLE
feature: publish container image to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push base-image
         uses: docker/build-push-action@v5
         with:
@@ -48,6 +54,8 @@ jobs:
           tags: |
             coderaiser/cloudcmd:latest
             coderaiser/cloudcmd:${{ steps.build.outputs.version }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.build.outputs.version }}
       - name: Build and push alpine-image
         uses: docker/build-push-action@v5
         with:
@@ -58,3 +66,5 @@ jobs:
           tags: |
             coderaiser/cloudcmd:latest-alpine
             coderaiser/cloudcmd:${{ steps.build.outputs.version }}-alpine
+            ghcr.io/${{ github.repository }}:latest-alpine
+            ghcr.io/${{ github.repository }}:${{ steps.build.outputs.version }}-alpine


### PR DESCRIPTION
Hi @coderaiser 👋🏼 

After this PR is merged and a container image is built and pushed, you might have to go to https://github.com/coderaiser?tab=packages and make it public

Fixes: #408

Thanks 🙏🏼 

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run fix:lint` is OK
- [x] `npm test` is OK
