### PR TITLE
chore(docker): Dockerimage update -Debian12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-buster
+FROM node:lts-bullseye
 LABEL maintainer="Coderaiser"
 
 RUN mkdir -p /usr/src/app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,9 @@ COPY . /usr/src/app
 
 WORKDIR /
 
-ENV cloudcmd_terminal true
-ENV cloudcmd_terminal_path gritty
-ENV cloudcmd_open false
+ENV cloudcmd_terminal=true
+ENV cloudcmd_terminal_path=gritty
+ENV cloudcmd_open=false
 
 EXPOSE 8000
 


### PR DESCRIPTION

Builds, but copies wrong dir to /usr/src/app/
I can't spend much time to solve this issue -but it's related to mine build environment.