### PR TITLE
feature:cloudcmd:add context menu option to toggle file selection

### DIFF
--- a/client/modules/menu.js
+++ b/client/modules/menu.js
@@ -126,6 +126,7 @@ function getMenuData(isAuth) {
             CloudCmd.Upload.show();
         },
         'Upload From Cloud': uploadFromCloud,
+        'Toggle File Selection': DOM.toggleSelectedFile,
         '(Un)Select All': DOM.toggleAllSelectedFiles,
     };
     

--- a/css/icons.css
+++ b/css/icons.css
@@ -83,6 +83,11 @@
     content: '\e811  ';
 }
 
+.icon-toggle-file-selection::before {
+    font-family: 'Fontello';
+    content: '\e809  ';
+}
+
 .icon-unselect-all::before {
     font-family: 'Fontello';
     content: '\e812  ';


### PR DESCRIPTION
Adds option 3 of suggestions on https://github.com/coderaiser/cloudcmd/issues/418

I selected an existing icon that i thought is good enough for this context menu option.

Could not manage to add new icon so far, needs some pointers in adding new icon (added one in  the svg file and fontello.json , but it did not work)

- [x] `npm run fix:lint` is OK
- [x] `npm test` is OK
