### PR TITLE
feature: cloudcmd: Prevent unselect being fired on panel click when in mobile view

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -60,6 +60,7 @@ function CloudCmdProto(DOM) {
     this.prefixURL = '';
     
     this.MIN_ONE_PANEL_WIDTH = 1155;
+    this.MOBILE_ONE_PANEL_WIDTH = 600;
     this.HOST = location.origin || location.protocol + '//' + location.host;
     
     this.TITLE = 'Cloud Commander';

--- a/client/listeners/index.js
+++ b/client/listeners/index.js
@@ -55,7 +55,7 @@ const {Events} = DOM;
 
 const EventsFiles = {
     mousedown: exec.with(execIfNotUL, setCurrentFileByEvent),
-    click: execAll([onClick, function(e)  { if (window.innerWidth > CloudCmd.MOBILE_ONE_PANEL_WIDTH) { unselect(e); } }]),
+    click: execAll([onClick, exec.with(execIfNotMobile, unselect)]),
     dragstart: exec.with(execIfNotUL, onDragStart),
     dblclick: exec.with(execIfNotUL, onDblClick),
     touchstart: exec.with(execIfNotUL, onTouch),
@@ -219,6 +219,12 @@ function copyPath(el) {
             .parentElement.title)
         .then(CloudCmd.log)
         .catch(CloudCmd.log);
+}
+
+function execIfNotMobile(callback , event)
+{
+    if (window.innerWidth > CloudCmd.MOBILE_ONE_PANEL_WIDTH)
+        callback(event);
 }
 
 function execIfNotUL(callback, event) {

--- a/client/listeners/index.js
+++ b/client/listeners/index.js
@@ -55,7 +55,7 @@ const {Events} = DOM;
 
 const EventsFiles = {
     mousedown: exec.with(execIfNotUL, setCurrentFileByEvent),
-    click: execAll([onClick, unselect]),
+    click: execAll([onClick, function(e)  { if (window.innerWidth > CloudCmd.MOBILE_ONE_PANEL_WIDTH) { unselect(e); } }]),
     dragstart: exec.with(execIfNotUL, onDragStart),
     dblclick: exec.with(execIfNotUL, onDblClick),
     touchstart: exec.with(execIfNotUL, onTouch),


### PR DESCRIPTION
As discussed on https://github.com/coderaiser/cloudcmd/issues/418

This will prevent "unselect" being called on panel click when in mobile view (determined by the hard coded screen width).

Tested the full scenario locally on my mobile and it works just fine.

