### PR TITLE
feat(menu): remove runtime dependency on esm.sh for Aleman menu

### DIFF
--- a/.rspack/js.js
+++ b/.rspack/js.js
@@ -56,6 +56,19 @@ const plugins = [
         resource.request = resource.request.replace(/^node:/, '');
     }),
     new NormalModuleReplacementPlugin(/^putout$/, '@putout/bundle'),
+    
+    new NormalModuleReplacementPlugin(
+        /^\.\/importmap\.js$/,
+        (resource) => {
+            if (!resource.context.endsWith('/node_modules/aleman/menu'))
+                return;
+            
+            resource.request = resolve(
+                rootDir,
+                'client/modules/menu/aleman-importmap.js',
+            );
+        },
+    ),
     new EnvironmentPlugin({
         NODE_ENV,
     }),
@@ -67,6 +80,13 @@ const plugins = [
 const splitChunks = {
     chunks: 'all',
     cacheGroups: {
+        alemanVendor: {
+            name: 'aleman-vendor',
+            test: /[\\/]node_modules[\\/](aleman|@putout[\\/](bundle|processor-html)|fullstore|jessy)[\\/]/,
+            chunks: 'async',
+            enforce: true,
+            priority: 20,
+        },
         abcCommon: {
             name: 'cloudcmd.common',
             chunks: (chunk) => {
@@ -80,6 +100,7 @@ const splitChunks = {
                     'user-menu',
                     'help',
                     'themes/dark',
+                    'aleman',
                     'themes/light',
                     'columns/name-size',
                     'columns/name-size-date',

--- a/client/cloudcmd.js
+++ b/client/cloudcmd.js
@@ -32,12 +32,6 @@ async function init(config) {
     const prefix = getPrefix(config.prefix);
     
     globalThis.CloudCmd.init(prefix, config);
-    
-    if (globalThis.CloudCmd.config('menu') === 'aleman')
-        setTimeout(() => {
-            import('https://esm.sh/@putout/processor-html');
-            import('https://esm.sh/@putout/bundle@5.5');
-        }, 100);
 }
 
 function getPrefix(prefix) {

--- a/client/modules/menu/aleman-importmap.js
+++ b/client/modules/menu/aleman-importmap.js
@@ -1,0 +1,3 @@
+export const importmap = {
+    imports: {},
+};

--- a/client/modules/menu/cloudmenu.js
+++ b/client/modules/menu/cloudmenu.js
@@ -14,10 +14,10 @@ export const createCloudMenu = async (fm, options, menuData) => {
 
 async function loadMenu() {
     if (CloudCmd.config('menu') === 'aleman') {
-        const {prefix} = CloudCmd;
-        const {host, protocol} = globalThis.location;
-        const url = `${protocol}//${host}${prefix}/node_modules/aleman/menu/menu.js`;
-        const {createMenu} = await import(/* webpackIgnore: true */url);
+        const {createMenu} = await import(
+            /* webpackChunkName: 'aleman' */
+            'aleman/menu',
+        );
         
         return createMenu;
     }
@@ -27,5 +27,6 @@ async function loadMenu() {
 
 function createSupermenu(name, options, menuData) {
     const element = document.querySelector('[data-name="js-fm"]');
+    
     return supermenu(element, options, menuData);
 }

--- a/html/index.html
+++ b/html/index.html
@@ -41,15 +41,5 @@
         <script>
             CloudCmd({{ config }});
         </script>
-        <script data-name="aleman-importmap" type="importmap">
-        {
-            "imports": {
-                "putout": "https://esm.sh/@putout/bundle@5.5",
-                "@putout/processor-html": "https://esm.sh/@putout/processor-html",
-                "fullstore": "https://esm.sh/fullstore",
-                "jessy": "https://esm.sh/jessy"
-            }
-        }
-        </script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@cloudcmd/fileop": "^9.0.7",
     "@cloudcmd/move-files": "^8.0.0",
     "@cloudcmd/read-files-sync": "^2.0.0",
+    "@putout/bundle": "^5.5.0",
     "@putout/cli-validate-args": "^2.0.0",
     "@putout/plugin-cloudcmd": "^5.2.0",
     "aleman": "^2.0.1",


### PR DESCRIPTION
- load Aleman menu from bundled module
- replace remote importmap with local implementation
- remove runtime imports to esm.sh
- keep Cloud Commander fully functional in offline environments

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [x] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [x] `npm run fix:lint` is OK
- [x] `npm test` is OK
